### PR TITLE
closes #4: Added Prometheus exporter and config validation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,12 +14,19 @@ subprojects {
     configurations {
         buildTools
     }
+
+    test {
+        useJUnitPlatform()
+    }
+
     dependencies {
         buildTools(
             'jarcheck:jarcheck:1.5'
         )
         compileOnly 'org.projectlombok:lombok:1.18.4'
         annotationProcessor 'org.projectlombok:lombok:1.18.4'
+        testImplementation 'org.junit.jupiter:junit-jupiter-api:5.3.1'
+        testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.3.1'
     }
 
     compileJava {
@@ -30,7 +37,6 @@ subprojects {
         sourceCompatibility = 1.8
         targetCompatibility = 1.8
     }
-    
 
     // use jarCheck to make sure all classes in our dependencies are at maximum in version 1.8
     task checkDependencyJavaVersions {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
 releaseVersion=0.1.M1
 openCensusVersion=0.18.0
+prometheusClientVersion=0.6.0

--- a/inspectit-oce-core/build.gradle
+++ b/inspectit-oce-core/build.gradle
@@ -58,7 +58,8 @@ dependencies {
     testImplementation(
             'org.springframework:spring-test:5.1.3.RELEASE',
             'org.apache.httpcomponents:httpclient:4.5.6',
-            'org.mockito:mockito-core:2.23.4'
+            'org.mockito:mockito-core:2.23.4',
+            'org.assertj:assertj-core:3.11.1'
     )
 
 }

--- a/inspectit-oce-core/build.gradle
+++ b/inspectit-oce-core/build.gradle
@@ -1,4 +1,3 @@
-
 plugins {
     id "me.champeau.gradle.jmh" version "0.4.7"
 }
@@ -43,9 +42,21 @@ dependencies {
     implementation(
             'org.springframework.boot:spring-boot:2.1.1.RELEASE',
             'org.yaml:snakeyaml:1.23',
+
+            //data validation
             'javax.validation:validation-api:2.0.0.Final',
-            'ch.qos.logback:logback-classic:1.2.3'
+            'org.hibernate.validator:hibernate-validator:6.0.2.Final',
+            'org.hibernate.validator:hibernate-validator-annotation-processor:6.0.2.Final',
+            'javax.el:javax.el-api:3.0.0',
+            'org.glassfish.web:javax.el:2.2.6',
+
+            'ch.qos.logback:logback-classic:1.2.3',
+            'javax.annotation:javax.annotation-api:1.3.2', //Required for @PostConstruct and @PreDestroy to work in Java9+
+            //OpenCensus exporters
+            "io.opencensus:opencensus-exporter-stats-prometheus:${openCensusVersion}",
+            "io.prometheus:simpleclient_httpserver:${prometheusClientVersion}"
     )
+
 }
 
 task buildOpencensusFatJar(type: Jar) {

--- a/inspectit-oce-core/build.gradle
+++ b/inspectit-oce-core/build.gradle
@@ -44,11 +44,8 @@ dependencies {
             'org.yaml:snakeyaml:1.23',
 
             //data validation
-            'javax.validation:validation-api:2.0.0.Final',
-            'org.hibernate.validator:hibernate-validator:6.0.2.Final',
-            'org.hibernate.validator:hibernate-validator-annotation-processor:6.0.2.Final',
-            'javax.el:javax.el-api:3.0.0',
-            'org.glassfish.web:javax.el:2.2.6',
+            'org.hibernate.validator:hibernate-validator:6.0.13.Final',
+            'org.apache.tomcat.embed:tomcat-embed-el:9.0.13',
 
             'ch.qos.logback:logback-classic:1.2.3',
             'javax.annotation:javax.annotation-api:1.3.2', //Required for @PostConstruct and @PreDestroy to work in Java9+

--- a/inspectit-oce-core/build.gradle
+++ b/inspectit-oce-core/build.gradle
@@ -27,6 +27,7 @@ jmh {
 
 configurations{
     opencensus
+    testImplementation.extendsFrom opencensus
 }
 
 dependencies {
@@ -52,6 +53,12 @@ dependencies {
             //OpenCensus exporters
             "io.opencensus:opencensus-exporter-stats-prometheus:${openCensusVersion}",
             "io.prometheus:simpleclient_httpserver:${prometheusClientVersion}"
+    )
+
+    testImplementation(
+            'org.springframework:spring-test:5.1.3.RELEASE',
+            'org.apache.httpcomponents:httpclient:4.5.6',
+            'org.mockito:mockito-core:2.23.4'
     )
 
 }

--- a/inspectit-oce-core/src/main/java/rocks/inspectit/oce/core/config/CaseUtils.java
+++ b/inspectit-oce-core/src/main/java/rocks/inspectit/oce/core/config/CaseUtils.java
@@ -1,0 +1,26 @@
+package rocks.inspectit.oce.core.config;
+
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class CaseUtils {
+
+    /**
+     * Converts the given camelCase String to kebab-case.
+     * Any other separator characters are note affected.
+     *
+     * @param str the string in camelCase
+     * @return the string in kebab-case
+     */
+    public String camelCaseToKebabCase(String str) {
+        int position = 0;
+        for (int i = 0; i < str.length() - 1; i++) {
+            char first = str.charAt(i);
+            char second = str.charAt(i + 1);
+            if (Character.isLowerCase(first) && Character.isUpperCase(second)) {
+                str = str.substring(0, i + 1) + "-" + Character.toLowerCase(second) + str.substring(i + 2);
+            }
+        }
+        return str;
+    }
+}

--- a/inspectit-oce-core/src/main/java/rocks/inspectit/oce/core/config/filebased/ConfigurationDirectoriesWatcher.java
+++ b/inspectit-oce-core/src/main/java/rocks/inspectit/oce/core/config/filebased/ConfigurationDirectoriesWatcher.java
@@ -4,7 +4,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import rocks.inspectit.oce.core.config.InspectitEnvironment;
-import rocks.inspectit.oce.core.config.service.ActivationConfigCondition;
+import rocks.inspectit.oce.core.service.ActivationConfigCondition;
 
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;

--- a/inspectit-oce-core/src/main/java/rocks/inspectit/oce/core/config/model/InspectitConfig.java
+++ b/inspectit-oce-core/src/main/java/rocks/inspectit/oce/core/config/model/InspectitConfig.java
@@ -1,9 +1,13 @@
 package rocks.inspectit.oce.core.config.model;
 
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import rocks.inspectit.oce.core.config.model.config.ConfigSettings;
+import rocks.inspectit.oce.core.config.model.exporters.ExportersSettings;
 
+import javax.validation.Valid;
 import javax.validation.constraints.Min;
+import javax.validation.constraints.NotBlank;
 
 /**
  * Root element of the configuration model for inspectIT.
@@ -18,28 +22,37 @@ import javax.validation.constraints.Min;
  * @author Jonas Kunz
  */
 @Data
+@NoArgsConstructor
 public class InspectitConfig {
 
     /**
      * The (symbolic) name of the service being instrumented
      */
-    String serviceName;
+    @NotBlank
+    private String serviceName;
 
     /**
      * Defines all configuration sources.
      */
-    ConfigSettings config;
+    @Valid
+    private ConfigSettings config = new ConfigSettings();
+
+    /**
+     * Settings for all OpenCensus exporters.
+     */
+    @Valid
+    private ExportersSettings exporters = new ExportersSettings();
 
     /**
      * Defines how many threads inspectIT may start for its internal tasks.
      */
     @Min(1)
-    int threadPoolSize;
+    private int threadPoolSize;
 
     /**
      * If true, the OpenCensus API and Implementation will be loaded by the bootstrap classloader.
      * Otherwise they will be loaded by the private inspectIT classloader.
      */
-    boolean publishOpencensusToBootstrap;
+    private boolean publishOpencensusToBootstrap;
 
 }

--- a/inspectit-oce-core/src/main/java/rocks/inspectit/oce/core/config/model/InspectitConfig.java
+++ b/inspectit-oce-core/src/main/java/rocks/inspectit/oce/core/config/model/InspectitConfig.java
@@ -44,6 +44,12 @@ public class InspectitConfig {
     private ExportersSettings exporters = new ExportersSettings();
 
     /**
+     * General metrics settings.
+     */
+    @Valid
+    private MetricsSettings metrics = new MetricsSettings();
+
+    /**
      * Defines how many threads inspectIT may start for its internal tasks.
      */
     @Min(1)

--- a/inspectit-oce-core/src/main/java/rocks/inspectit/oce/core/config/model/MetricsSettings.java
+++ b/inspectit-oce-core/src/main/java/rocks/inspectit/oce/core/config/model/MetricsSettings.java
@@ -1,0 +1,16 @@
+package rocks.inspectit.oce.core.config.model;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class MetricsSettings {
+
+    /**
+     * Master switch for disabling metrics capturing and exporting.
+     * If disabled the following happens:
+     * - all metrics exporters are disabled
+     */
+    boolean enabled;
+}

--- a/inspectit-oce-core/src/main/java/rocks/inspectit/oce/core/config/model/config/ConfigSettings.java
+++ b/inspectit-oce-core/src/main/java/rocks/inspectit/oce/core/config/model/config/ConfigSettings.java
@@ -1,16 +1,18 @@
 package rocks.inspectit.oce.core.config.model.config;
 
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 /**
  * Defines the settings for all configuration sources
  */
 @Data
+@NoArgsConstructor
 public class ConfigSettings {
 
     /**
      * Settings for file-based configuration input.
      */
-    FileBasedConfigSettings fileBased;
+    private FileBasedConfigSettings fileBased;
 
 }

--- a/inspectit-oce-core/src/main/java/rocks/inspectit/oce/core/config/model/config/FileBasedConfigSettings.java
+++ b/inspectit-oce-core/src/main/java/rocks/inspectit/oce/core/config/model/config/FileBasedConfigSettings.java
@@ -1,6 +1,7 @@
 package rocks.inspectit.oce.core.config.model.config;
 
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 /**
  * If path is not null and enabled is true a {@link rocks.inspectit.oce.core.config.filebased.DirectoryPropertySource}
@@ -8,20 +9,21 @@ import lombok.Data;
  * and can configure other configuration sources.
  */
 @Data
+@NoArgsConstructor
 public class FileBasedConfigSettings {
     /**
      * The path to the directory containing the .yml or .properties files.
      * Can be null or empty, in which case no file based configuration is used.
      */
-    String path;
+    private String path;
 
     /**
      * Can be used to disable the file based config while the path is still specified.
      */
-    boolean enabled;
+    private boolean enabled;
 
     /**
      * If true, a {@link rocks.inspectit.oce.core.config.filebased.ConfigurationDirectoriesWatcher} will be started to reload the configuration from the directory on changes.
      */
-    boolean watch;
+    private boolean watch;
 }

--- a/inspectit-oce-core/src/main/java/rocks/inspectit/oce/core/config/model/exporters/ExportersSettings.java
+++ b/inspectit-oce-core/src/main/java/rocks/inspectit/oce/core/config/model/exporters/ExportersSettings.java
@@ -1,0 +1,19 @@
+package rocks.inspectit.oce.core.config.model.exporters;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import rocks.inspectit.oce.core.config.model.exporters.metrics.MetricsExportersSettings;
+
+import javax.validation.Valid;
+
+/**
+ * Settings for metrics and trace exporters of OpenCensus.
+ */
+@Data
+@NoArgsConstructor
+public class ExportersSettings {
+
+    @Valid
+    private MetricsExportersSettings metrics;
+
+}

--- a/inspectit-oce-core/src/main/java/rocks/inspectit/oce/core/config/model/exporters/metrics/MetricsExportersSettings.java
+++ b/inspectit-oce-core/src/main/java/rocks/inspectit/oce/core/config/model/exporters/metrics/MetricsExportersSettings.java
@@ -1,0 +1,17 @@
+package rocks.inspectit.oce.core.config.model.exporters.metrics;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.validation.Valid;
+
+/**
+ * Settings for metrics exporters.
+ */
+@Data
+@NoArgsConstructor
+public class MetricsExportersSettings {
+
+    @Valid
+    private PrometheusExporterSettings prometheus;
+}

--- a/inspectit-oce-core/src/main/java/rocks/inspectit/oce/core/config/model/exporters/metrics/PrometheusExporterSettings.java
+++ b/inspectit-oce-core/src/main/java/rocks/inspectit/oce/core/config/model/exporters/metrics/PrometheusExporterSettings.java
@@ -1,0 +1,34 @@
+package rocks.inspectit.oce.core.config.model.exporters.metrics;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotBlank;
+
+/**
+ * Settings for the OpenCensus Prometheus metrics exporter.
+ */
+@Data
+@NoArgsConstructor
+public class PrometheusExporterSettings {
+
+    /**
+     * If true, the inspectIT Agent will try to start a Prometheus metrics exporter.
+     */
+    private boolean enabled;
+
+    /**
+     * The hostname on which the /metrics endpoint of prometheus will be started.
+     */
+    @NotBlank
+    private String host;
+
+    /**
+     * The port on which the /metrics endpoint of prometheus will be started.
+     */
+    @Min(0)
+    @Max(65535)
+    private int port;
+}

--- a/inspectit-oce-core/src/main/java/rocks/inspectit/oce/core/exporter/PrometheusExporterService.java
+++ b/inspectit-oce-core/src/main/java/rocks/inspectit/oce/core/exporter/PrometheusExporterService.java
@@ -22,12 +22,12 @@ public class PrometheusExporterService extends DynamicallyActivatableService {
     private HTTPServer prometheusClient = null;
 
     public PrometheusExporterService() {
-        super("exporters.metrics.prometheus");
+        super("exporters.metrics.prometheus", "metrics.enabled");
     }
 
     @Override
     protected boolean checkEnabledForConfig(InspectitConfig conf) {
-        return conf.getExporters().getMetrics().getPrometheus().isEnabled();
+        return conf.getExporters().getMetrics().getPrometheus().isEnabled() && conf.getMetrics().isEnabled();
     }
 
     @Override
@@ -38,7 +38,7 @@ public class PrometheusExporterService extends DynamicallyActivatableService {
             int port = config.getPort();
             log.info("Starting Prometheus Exporter on {}:{}", host, port);
             PrometheusStatsCollector.createAndRegister(PrometheusStatsConfiguration.builder().setRegistry(defaultRegistry).build());
-            prometheusClient = new HTTPServer(/*host*/ host, /*port*/  port, /*daemon*/ true);
+            prometheusClient = new HTTPServer(host, port, true);
         } catch (Exception e) {
             log.error("Error Starting Prometheus HTTP Endpoint!", e);
             defaultRegistry.clear();

--- a/inspectit-oce-core/src/main/java/rocks/inspectit/oce/core/exporter/PrometheusExporterService.java
+++ b/inspectit-oce-core/src/main/java/rocks/inspectit/oce/core/exporter/PrometheusExporterService.java
@@ -1,0 +1,59 @@
+package rocks.inspectit.oce.core.exporter;
+
+import io.opencensus.exporter.stats.prometheus.PrometheusStatsCollector;
+import io.opencensus.exporter.stats.prometheus.PrometheusStatsConfiguration;
+import io.prometheus.client.exporter.HTTPServer;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.springframework.stereotype.Component;
+import rocks.inspectit.oce.core.config.model.InspectitConfig;
+import rocks.inspectit.oce.core.service.DynamicallyActivatableService;
+
+import static io.prometheus.client.CollectorRegistry.defaultRegistry;
+
+/**
+ * Service for the Prometheus OpenCensus exporter.
+ * Can be dynamically started and stopped using the exporters.metrics.prometheus.enabled configuration.
+ */
+@Component
+@Slf4j
+public class PrometheusExporterService extends DynamicallyActivatableService {
+
+    private HTTPServer prometheusClient = null;
+
+    public PrometheusExporterService() {
+        super("exporters.metrics.prometheus");
+    }
+
+    @Override
+    protected boolean checkEnabledForConfig(InspectitConfig conf) {
+        return conf.getExporters().getMetrics().getPrometheus().isEnabled();
+    }
+
+    @Override
+    protected boolean doEnable(InspectitConfig configuration) {
+        val config = configuration.getExporters().getMetrics().getPrometheus();
+        try {
+            String host = config.getHost();
+            int port = config.getPort();
+            log.info("Starting Prometheus Exporter on {}:{}", host, port);
+            PrometheusStatsCollector.createAndRegister(PrometheusStatsConfiguration.builder().setRegistry(defaultRegistry).build());
+            prometheusClient = new HTTPServer(/*host*/ host, /*port*/  port, /*daemon*/ true);
+        } catch (Exception e) {
+            log.error("Error Starting Prometheus HTTP Endpoint!", e);
+            defaultRegistry.clear();
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    protected boolean doDisable() {
+        log.info("Stopping Prometheus Exporter");
+        if (prometheusClient != null) {
+            prometheusClient.stop();
+            defaultRegistry.clear();
+        }
+        return true;
+    }
+}

--- a/inspectit-oce-core/src/main/java/rocks/inspectit/oce/core/service/ActivationConfigCondition.java
+++ b/inspectit-oce-core/src/main/java/rocks/inspectit/oce/core/service/ActivationConfigCondition.java
@@ -1,4 +1,4 @@
-package rocks.inspectit.oce.core.config.service;
+package rocks.inspectit.oce.core.service;
 
 import org.springframework.context.annotation.Conditional;
 import rocks.inspectit.oce.core.config.model.config.FileBasedConfigSettings;

--- a/inspectit-oce-core/src/main/java/rocks/inspectit/oce/core/service/ActivationConfigConditionMet.java
+++ b/inspectit-oce-core/src/main/java/rocks/inspectit/oce/core/service/ActivationConfigConditionMet.java
@@ -1,4 +1,4 @@
-package rocks.inspectit.oce.core.config.service;
+package rocks.inspectit.oce.core.service;
 
 import lombok.val;
 import org.springframework.context.annotation.Condition;

--- a/inspectit-oce-core/src/main/java/rocks/inspectit/oce/core/service/DynamicallyActivatableService.java
+++ b/inspectit-oce-core/src/main/java/rocks/inspectit/oce/core/service/DynamicallyActivatableService.java
@@ -19,7 +19,7 @@ import java.util.stream.Collectors;
 
 /**
  * Base class for services which can be dynamically enabled and disabled based on the {@link InspectitConfig}.
- * This class handels the waiting for changes in the configuration.
+ * This class handles the waiting for changes in the configuration.
  * If relevant changes to the configuration occur, this class ensures that the service is properly restarted.
  */
 public abstract class DynamicallyActivatableService {
@@ -38,7 +38,7 @@ public abstract class DynamicallyActivatableService {
     /**
      * Constructor.
      *
-     * @param configDependencies The list of configuration properties this service depends on.
+     * @param configDependencies The list of configuration properties in camelCase this service depends on.
      *                           For example "exporters.metrics.prometheus" specifies a dependency
      *                           to {@link rocks.inspectit.oce.core.config.model.exporters.metrics.PrometheusExporterSettings}
      *                           and all its children.

--- a/inspectit-oce-core/src/main/java/rocks/inspectit/oce/core/service/DynamicallyActivatableService.java
+++ b/inspectit-oce-core/src/main/java/rocks/inspectit/oce/core/service/DynamicallyActivatableService.java
@@ -1,0 +1,141 @@
+package rocks.inspectit.oce.core.service;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.event.EventListener;
+import org.springframework.expression.Expression;
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import rocks.inspectit.oce.core.config.InspectitConfigChangedEvent;
+import rocks.inspectit.oce.core.config.InspectitEnvironment;
+import rocks.inspectit.oce.core.config.model.InspectitConfig;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * Base class for services which can be dynamically enabled and disabled based on the {@link InspectitConfig}.
+ * This class handels the waiting for changes in the configuration.
+ * If relevant changes to the configuration occur, this class ensures that the service is properly restarted.
+ */
+public abstract class DynamicallyActivatableService {
+
+    @Autowired
+    protected InspectitEnvironment env;
+
+    private List<Expression> configDependencies;
+
+    /**
+     * True if the service is currently enabled.
+     */
+    @Getter
+    private boolean enabled = false;
+
+    /**
+     * Constructor.
+     *
+     * @param configDependencies The list of configuration properties this service depends on.
+     *                           For example "exporters.metrics.prometheus" specifies a dependency
+     *                           to {@link rocks.inspectit.oce.core.config.model.exporters.metrics.PrometheusExporterSettings}
+     *                           and all its children.
+     */
+    public DynamicallyActivatableService(String... configDependencies) {
+        ExpressionParser parser = new SpelExpressionParser();
+        this.configDependencies = Arrays.stream(configDependencies)
+                .map(parser::parseExpression)
+                .collect(Collectors.toList());
+    }
+
+    @PostConstruct
+    void initialize() {
+        if (checkEnabledForConfig(env.getCurrentConfig())) {
+            enabled = enable();
+        } else {
+            enabled = false;
+        }
+    }
+
+    /**
+     * Tries to enable the service if it is not already enabled.
+     * Usually should not be called directly. Instead it is called automatically when configuration changes occur.
+     *
+     * @return true, if the service is now running
+     */
+    synchronized boolean enable() {
+        if (!enabled) {
+            enabled = doEnable(env.getCurrentConfig());
+        }
+        return enabled;
+    }
+
+    /**
+     * Tries to disable the service if it is currently enabled.
+     * Usually should not be called directly. Instead it is called automatically when configuration changes occur.
+     *
+     * @return true, if the service is now stopped
+     */
+    @PreDestroy
+    synchronized boolean disable() {
+        if (enabled) {
+            enabled = !doDisable();
+        }
+        return !enabled;
+    }
+
+    @EventListener(InspectitConfigChangedEvent.class)
+    synchronized void checkForUpdates(InspectitConfigChangedEvent ev) {
+        boolean affected = false;
+        for (Expression exp : configDependencies) {
+            Object oldVal = exp.getValue(ev.getOldConfig());
+            Object newVal = exp.getValue(ev.getNewConfig());
+            boolean isEqual = Objects.equals(oldVal, newVal);
+            if (!isEqual) {
+                affected = true;
+            }
+        }
+        if (affected) {
+            if (enabled) {
+                disable();
+                if (enabled) {
+                    return; // could not disable the service and therefore cannot reenable it
+                }
+            }
+            if (checkEnabledForConfig(ev.getNewConfig())) {
+                enable();
+            }
+        }
+    }
+
+    /**
+     * The implementation of this method checks if the service should be enabled given a certain configuration.
+     * When changes to the configuration occur, this method will be used to correctly invoke {@link #doDisable()} and {@link #doEnable()}.
+     *
+     * @param conf the configuration to check
+     * @return
+     */
+    protected abstract boolean checkEnabledForConfig(InspectitConfig conf);
+
+    /**
+     * Called when the service should start.
+     * This performs the actual enabling logic.
+     * If the enabling is not successful, this method has to perform the cleanup.
+     *
+     * @param configuration the configuration used to start the service. Is the same configuration as {@link InspectitEnvironment#getCurrentConfig()}.
+     * @return true if the enabling was successful, false otherwise.
+     */
+    protected abstract boolean doEnable(InspectitConfig configuration);
+
+    /**
+     * Called when the service is running and should be stopped.
+     * This is guaranteed to be only called when previously {@link #doEnable(InspectitConfig)} was called and was successful.
+     *
+     * @return true, if te disabling was successful. false if the service could not be disabled and is still running.
+     */
+    protected abstract boolean doDisable();
+
+
+}

--- a/inspectit-oce-core/src/main/resources/config/default.yml
+++ b/inspectit-oce-core/src/main/resources/config/default.yml
@@ -17,19 +17,24 @@ inspectit:
       # if true the directory will be watched for changes. When changes occur, the configuration is automatically reloaded
       watch: true
 
-  #settings for configuring OpenCensus stats and trace exporters
+  # settings for configuring OpenCensus stats and trace exporters
   exporters:
-    #settings for metrics exporters
+    # settings for metrics exporters
     metrics:
-      #settings for the prometheus exporter (https://github.com/census-instrumentation/opencensus-java/tree/master/exporters/stats/prometheus)
+      # settings for the prometheus exporter (https://github.com/census-instrumentation/opencensus-java/tree/master/exporters/stats/prometheus)
       prometheus:
-        #if true, the agent will try to start the Prometheus stats exporter
+        # if true, the agent will try to start the Prometheus stats exporter
         enabled: false
-        #The hostname or IP-address on which the /metrics endpoint of prometheus will be started.
+        # the hostname or IP-address on which the /metrics endpoint of prometheus will be started.
         host: localhost
-        #The port on which the /metrics endpoint of prometheus will be started.
+        # the port on which the /metrics endpoint of prometheus will be started
         port: 8888
 
+  # general settings regarding metrics capturing
+  metrics:
+    # master switch for metrics capturing. When set to false the following happens:
+    #  - all metrics exporters are disabled
+    enabled: true
 
   # defines how many threads inspectIT may start for its internal tasks
   thread-pool-size: 2

--- a/inspectit-oce-core/src/main/resources/config/default.yml
+++ b/inspectit-oce-core/src/main/resources/config/default.yml
@@ -24,7 +24,7 @@ inspectit:
       # settings for the prometheus exporter (https://github.com/census-instrumentation/opencensus-java/tree/master/exporters/stats/prometheus)
       prometheus:
         # if true, the agent will try to start the Prometheus stats exporter
-        enabled: false
+        enabled: true
         # the hostname or IP-address on which the /metrics endpoint of prometheus will be started.
         host: localhost
         # the port on which the /metrics endpoint of prometheus will be started

--- a/inspectit-oce-core/src/main/resources/config/default.yml
+++ b/inspectit-oce-core/src/main/resources/config/default.yml
@@ -17,6 +17,20 @@ inspectit:
       # if true the directory will be watched for changes. When changes occur, the configuration is automatically reloaded
       watch: true
 
+  #settings for configuring OpenCensus stats and trace exporters
+  exporters:
+    #settings for metrics exporters
+    metrics:
+      #settings for the prometheus exporter (https://github.com/census-instrumentation/opencensus-java/tree/master/exporters/stats/prometheus)
+      prometheus:
+        #if true, the agent will try to start the Prometheus stats exporter
+        enabled: false
+        #The hostname or IP-address on which the /metrics endpoint of prometheus will be started.
+        host: localhost
+        #The port on which the /metrics endpoint of prometheus will be started.
+        port: 8888
+
+
   # defines how many threads inspectIT may start for its internal tasks
   thread-pool-size: 2
 

--- a/inspectit-oce-core/src/test/java/rocks/inspectit/oce/core/SpringTestBase.java
+++ b/inspectit-oce-core/src/test/java/rocks/inspectit/oce/core/SpringTestBase.java
@@ -98,7 +98,6 @@ public class SpringTestBase {
 
             InspectitEnvironment env = new TestInspectitEnvironment(ctx);
             ctx.setEnvironment(env);
-            //TODO: mock Instrumentation class and add to the context
         }
     }
 

--- a/inspectit-oce-core/src/test/java/rocks/inspectit/oce/core/SpringTestBase.java
+++ b/inspectit-oce-core/src/test/java/rocks/inspectit/oce/core/SpringTestBase.java
@@ -1,0 +1,132 @@
+package rocks.inspectit.oce.core;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.Appender;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MutablePropertySources;
+import org.springframework.core.env.PropertySource;
+import org.springframework.core.env.StandardEnvironment;
+import org.springframework.mock.env.MockPropertySource;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import rocks.inspectit.oce.core.config.InspectitEnvironment;
+import rocks.inspectit.oce.core.config.SpringConfiguration;
+
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import static org.mockito.Mockito.*;
+
+/**
+ * Base class for all tests.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = SpringConfiguration.class, initializers = SpringTestBase.TestContextInitializer.class)
+@TestPropertySource(properties = {
+        "inspectit.config.file-based.watch=false"
+})
+public class SpringTestBase {
+
+    @Autowired
+    private TestContextInitializer.TestInspectitEnvironment env;
+
+    private Appender<ILoggingEvent> mockAppender;
+
+
+    /**
+     * Allows to customize properties while the Context is open.
+     * This method is based on {@link InspectitEnvironment#updatePropertySources(Consumer)},
+     * which therefore also triggers {@link rocks.inspectit.oce.core.config.InspectitConfigChangedEvent}s.
+     * <p>
+     * Any test using this method should also hav the {@link org.springframework.test.annotation.DirtiesContext} annotation.
+     *
+     * @param propsCustomizer the lambda for customizing the properties.
+     */
+    public void updateProperties(Consumer<MockPropertySource> propsCustomizer) {
+        env.updatePropertySources((propsList) -> {
+            propsCustomizer.accept(env.mockProperties);
+        });
+    }
+
+    static class TestContextInitializer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+
+        /**
+         * This "hack" of a nested class has to be used because there is no other way of passing the soures to customizePropertySources
+         * prior to the call of the superconstructor.
+         */
+        List<PropertySource> testPropertySources;
+
+        class TestInspectitEnvironment extends InspectitEnvironment {
+
+            MockPropertySource mockProperties;
+
+
+            public TestInspectitEnvironment(ConfigurableApplicationContext ctx) {
+                super(ctx);
+            }
+
+            @Override
+            protected void customizePropertySources(MutablePropertySources propsList) {
+                mockProperties = new MockPropertySource();
+                propsList.addFirst(mockProperties);
+                testPropertySources.forEach(propsList::addLast);
+                super.customizePropertySources(propsList);
+            }
+        }
+
+        @Override
+        public void initialize(ConfigurableApplicationContext ctx) {
+            ConfigurableEnvironment defaultEnv = ctx.getEnvironment();
+
+            testPropertySources = defaultEnv.getPropertySources().stream()
+                    .filter(ps -> ps.getName() != StandardEnvironment.SYSTEM_ENVIRONMENT_PROPERTY_SOURCE_NAME)
+                    .filter(ps -> ps.getName() != StandardEnvironment.SYSTEM_PROPERTIES_PROPERTY_SOURCE_NAME)
+                    .collect(Collectors.toList());
+
+            InspectitEnvironment env = new TestInspectitEnvironment(ctx);
+            ctx.setEnvironment(env);
+            //TODO: mock Instrumentation class and add to the context
+        }
+    }
+
+    @BeforeEach
+    void addMockAppender() {
+        mockAppender = Mockito.mock(Appender.class);
+        Logger root = (Logger) LoggerFactory.getLogger(ch.qos.logback.classic.Logger.ROOT_LOGGER_NAME);
+        when(mockAppender.getName()).thenReturn("MOCK");
+        root.addAppender(mockAppender);
+        reset(mockAppender);
+    }
+
+    @AfterEach
+    void removeMockAppender() {
+        Logger root = (Logger) LoggerFactory.getLogger(ch.qos.logback.classic.Logger.ROOT_LOGGER_NAME);
+        root.detachAppender(mockAppender);
+    }
+
+    /**
+     * Asserts that no log output greater or equal to the given level are produced by the given test.
+     *
+     * @param level the level to compare against.
+     */
+    public void assertNoLogsOfLevelorGreater(Level level) {
+        ArgumentCaptor<ILoggingEvent> sentLogs = ArgumentCaptor.forClass(ILoggingEvent.class);
+        verify(mockAppender, times(0)).doAppend(argThat(
+                (le) -> le.getLevel().isGreaterOrEqual(level)));
+    }
+
+
+}

--- a/inspectit-oce-core/src/test/java/rocks/inspectit/oce/core/config/CaseUtilTest.java
+++ b/inspectit-oce-core/src/test/java/rocks/inspectit/oce/core/config/CaseUtilTest.java
@@ -1,0 +1,16 @@
+package rocks.inspectit.oce.core.config;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class CaseUtilTest {
+
+    @Test
+    void testCamelCaseToKebabCase() {
+        assertEquals(CaseUtils.camelCaseToKebabCase("testName"), "test-name");
+        assertEquals(CaseUtils.camelCaseToKebabCase("testNameAB"), "test-name-a-b");
+        assertEquals(CaseUtils.camelCaseToKebabCase("test"), "test");
+        assertEquals(CaseUtils.camelCaseToKebabCase("myPath.exampleClass"), "my-path.example-class");
+    }
+}

--- a/inspectit-oce-core/src/test/java/rocks/inspectit/oce/core/exporter/PrometheusExporterIntTest.java
+++ b/inspectit-oce-core/src/test/java/rocks/inspectit/oce/core/exporter/PrometheusExporterIntTest.java
@@ -15,7 +15,7 @@ import rocks.inspectit.oce.core.SpringTestBase;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class PrometheusExporterTest extends SpringTestBase {
+public class PrometheusExporterIntTest extends SpringTestBase {
 
     private static final int HTTP_TIMEOUT = 1000;
 

--- a/inspectit-oce-core/src/test/java/rocks/inspectit/oce/core/exporter/PrometheusExporterTest.java
+++ b/inspectit-oce-core/src/test/java/rocks/inspectit/oce/core/exporter/PrometheusExporterTest.java
@@ -1,0 +1,88 @@
+package rocks.inspectit.oce.core.exporter;
+
+import ch.qos.logback.classic.Level;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.conn.ConnectTimeoutException;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.annotation.DirtiesContext;
+import rocks.inspectit.oce.core.SpringTestBase;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class PrometheusExporterTest extends SpringTestBase {
+
+    private static final int HTTP_TIMEOUT = 1000;
+
+    static CloseableHttpClient testClient;
+
+
+    @BeforeAll
+    static void initClient() {
+        RequestConfig.Builder requestBuilder = RequestConfig.custom();
+        requestBuilder = requestBuilder.setConnectTimeout(HTTP_TIMEOUT);
+        requestBuilder = requestBuilder.setConnectionRequestTimeout(HTTP_TIMEOUT);
+
+        HttpClientBuilder builder = HttpClientBuilder.create();
+        builder.setDefaultRequestConfig(requestBuilder.build());
+        testClient = builder.build();
+    }
+
+    @AfterAll
+    static void closeClient() throws Exception {
+        testClient.close();
+    }
+
+    void assertGet200(String url) throws Exception {
+        assertEquals(200, testClient.execute(new HttpGet(url)).getStatusLine().getStatusCode(), "Status code was not 200");
+    }
+
+    void assertUnavailable(String url) throws Exception {
+        assertThrows(ConnectTimeoutException.class,
+                () -> testClient.execute(new HttpGet(url)).getStatusLine().getStatusCode(), "Service was expected to be unavailable!");
+    }
+
+    @Test
+    void testDefaultSettings() throws Exception {
+        assertGet200("http://localhost:8888");
+        assertNoLogsOfLevelorGreater(Level.WARN);
+    }
+
+
+    @DirtiesContext
+    @Test
+    void testMasterSwitch() throws Exception {
+        updateProperties(props -> {
+            props.setProperty("inspectit.metrics.enabled", "false");
+        });
+        assertUnavailable("http://localhost:8888");
+        assertNoLogsOfLevelorGreater(Level.WARN);
+    }
+
+    @DirtiesContext
+    @Test
+    void testLocalSwitch() throws Exception {
+        updateProperties(props -> {
+            props.setProperty("inspectit.exporters.metrics.prometheus.enabled", "false");
+        });
+        assertUnavailable("http://localhost:8888");
+        assertNoLogsOfLevelorGreater(Level.WARN);
+    }
+
+
+    @DirtiesContext
+    @Test
+    void testChangePort() throws Exception {
+        updateProperties(props -> {
+            props.setProperty("inspectit.exporters.metrics.prometheus.port", "8899");
+        });
+        assertUnavailable("http://localhost:8888");
+        assertGet200("http://localhost:8899");
+        assertNoLogsOfLevelorGreater(Level.WARN);
+    }
+}


### PR DESCRIPTION
- extended the Agent with a base class for services which can be dynamically activated, deactivated and configured through the inspectIT configuration mechanism
- the prometheus OpenCensus exporter was added as a dynamic service (can be enabled, disabled and reconfigured at runtime)
- added config validation via the hibernate implementation
- moved the package rocks.inspectit.oce.config.service to rocks.inspectit.oce.service