### PR TITLE
closes #8: support for common tags and tag providers

### DIFF
--- a/inspectit-oce-core/src/main/java/rocks/inspectit/oce/core/config/model/InspectitConfig.java
+++ b/inspectit-oce-core/src/main/java/rocks/inspectit/oce/core/config/model/InspectitConfig.java
@@ -5,6 +5,8 @@ import lombok.NoArgsConstructor;
 import rocks.inspectit.oce.core.config.model.config.ConfigSettings;
 import rocks.inspectit.oce.core.config.model.exporters.ExportersSettings;
 import rocks.inspectit.oce.core.config.model.logging.LoggingSettings;
+import rocks.inspectit.oce.core.config.model.metrics.MetricsSettings;
+import rocks.inspectit.oce.core.config.model.tags.TagsSettings;
 
 import javax.validation.Valid;
 import javax.validation.constraints.Min;
@@ -31,6 +33,12 @@ public class InspectitConfig {
      */
     @NotBlank
     private String serviceName;
+
+    /**
+     * Common tags settings.
+     */
+    @Valid
+    private TagsSettings tags;
 
     /**
      * Defines all configuration sources.

--- a/inspectit-oce-core/src/main/java/rocks/inspectit/oce/core/config/model/metrics/MetricsSettings.java
+++ b/inspectit-oce-core/src/main/java/rocks/inspectit/oce/core/config/model/metrics/MetricsSettings.java
@@ -1,4 +1,4 @@
-package rocks.inspectit.oce.core.config.model;
+package rocks.inspectit.oce.core.config.model.metrics;
 
 import lombok.Data;
 import lombok.NoArgsConstructor;

--- a/inspectit-oce-core/src/main/java/rocks/inspectit/oce/core/config/model/tags/TagsSettings.java
+++ b/inspectit-oce-core/src/main/java/rocks/inspectit/oce/core/config/model/tags/TagsSettings.java
@@ -1,0 +1,26 @@
+package rocks.inspectit.oce.core.config.model.tags;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import rocks.inspectit.oce.core.config.model.tags.providers.TagsProvidersSettings;
+
+import javax.validation.Valid;
+import java.util.HashMap;
+import java.util.Map;
+
+@Data
+@NoArgsConstructor
+public class TagsSettings {
+
+    /**
+     * Settings for available tags providers.
+     */
+    @Valid
+    private TagsProvidersSettings providers;
+
+    /**
+     * Map of arbitrary user defined tags.
+     */
+    private final Map<String, String> extra = new HashMap<>();
+
+}

--- a/inspectit-oce-core/src/main/java/rocks/inspectit/oce/core/config/model/tags/providers/EnvironmentTagsProviderSettings.java
+++ b/inspectit-oce-core/src/main/java/rocks/inspectit/oce/core/config/model/tags/providers/EnvironmentTagsProviderSettings.java
@@ -1,0 +1,25 @@
+package rocks.inspectit.oce.core.config.model.tags.providers;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class EnvironmentTagsProviderSettings {
+
+    /**
+     * If providers is enabled.
+     */
+    private boolean enabled;
+
+    /**
+     * If true tries to resolve the host name using {@link java.net.InetAddress}.
+     */
+    private boolean resolveHostName;
+
+    /**
+     * If true tries to resolve the host address using {@link java.net.InetAddress}.
+     */
+    private boolean resolveHostAddress;
+
+}

--- a/inspectit-oce-core/src/main/java/rocks/inspectit/oce/core/config/model/tags/providers/TagsProvidersSettings.java
+++ b/inspectit-oce-core/src/main/java/rocks/inspectit/oce/core/config/model/tags/providers/TagsProvidersSettings.java
@@ -1,0 +1,18 @@
+package rocks.inspectit.oce.core.config.model.tags.providers;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.validation.Valid;
+
+@Data
+@NoArgsConstructor
+public class TagsProvidersSettings {
+
+    /**
+     * The environment tags providers.
+     */
+    @Valid
+    private EnvironmentTagsProviderSettings environment;
+
+}

--- a/inspectit-oce-core/src/main/java/rocks/inspectit/oce/core/tags/AbstractTagsProvider.java
+++ b/inspectit-oce-core/src/main/java/rocks/inspectit/oce/core/tags/AbstractTagsProvider.java
@@ -1,0 +1,66 @@
+package rocks.inspectit.oce.core.tags;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import rocks.inspectit.oce.core.config.model.InspectitConfig;
+import rocks.inspectit.oce.core.service.DynamicallyActivatableService;
+
+import java.util.Collections;
+import java.util.Map;
+
+public abstract class AbstractTagsProvider extends DynamicallyActivatableService implements ITagsProvider {
+
+    @Autowired
+    private CommonTagsManager commonTagsManager;
+
+    /**
+     * Internal tags.
+     */
+    private Map<String, String> tags = Collections.emptyMap();
+
+    /**
+     * Constructor that delegates config dependencies to the {@link DynamicallyActivatableService}.
+     *
+     * @param configDependencies configuration dependencies
+     */
+    public AbstractTagsProvider(String... configDependencies) {
+        super(configDependencies);
+    }
+
+    protected abstract Map<String, String> resolveTagsInternal(InspectitConfig configuration);
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected boolean doEnable(InspectitConfig configuration) {
+        tags = resolveTagsInternal(configuration);
+        commonTagsManager.register(this);
+        return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected boolean doDisable() {
+        commonTagsManager.unregister(this);
+        return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isEnabled() {
+        return super.isEnabled();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Map<String, String> getTags() {
+        return Collections.unmodifiableMap(tags);
+    }
+
+}

--- a/inspectit-oce-core/src/main/java/rocks/inspectit/oce/core/tags/CommonTagsManager.java
+++ b/inspectit-oce-core/src/main/java/rocks/inspectit/oce/core/tags/CommonTagsManager.java
@@ -1,0 +1,108 @@
+package rocks.inspectit.oce.core.tags;
+
+import io.opencensus.common.Scope;
+import io.opencensus.tags.*;
+import org.springframework.stereotype.Component;
+
+import java.util.*;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * Component that provides tags that should be considered as common and used when ever a metric is recorded.
+ */
+@Component
+public class CommonTagsManager {
+
+    /**
+     * All {@link ITagsProvider}s registered in the manager.
+     */
+    private final List<ITagsProvider> providers = new CopyOnWriteArrayList<>();
+
+    /**
+     * OpenCensus tag context representing common tag context.
+     */
+    private TagContext commonTagContext;
+
+    /**
+     * List of common tag keys that can be used when creating the views.
+     */
+    private List<TagKey> commonTagKeys;
+
+    /**
+     * Returns common tags keys that all view should register.
+     *
+     * @return Returns common tags keys that all view should register.
+     */
+    public List<TagKey> getCommonTagKeys() {
+        return Collections.unmodifiableList(commonTagKeys);
+    }
+
+    /**
+     * Returns newly created scope with common tag context. Metrics collectors should use this Scope with the try/resource block:
+     * <code>
+     * try (Scope scope = withCommonTagScope()) {
+     * Stats.getStatsRecorder().newMeasureMap().put(M_ERRORS, 1L).record();
+     * }
+     * </code>
+     *
+     * @return Returns newly created scope with default tag context.
+     */
+    public Scope withCommonTagScope() {
+        return Tags.getTagger().withTagContext(commonTagContext);
+    }
+
+    /**
+     * Returns default tag context. For testing.
+     *
+     * @return Returns default tag context.
+     */
+    TagContext getCommonTagContext() {
+        return commonTagContext;
+    }
+
+    /**
+     * Registers a tag provider.
+     *
+     * @param tagsProvider ITagProvider
+     */
+    public void register(ITagsProvider tagsProvider) {
+        if (!providers.contains(tagsProvider)) {
+            providers.add(tagsProvider);
+            createDefaults();
+        }
+    }
+
+    /**
+     * Unregisters a tag provider.
+     *
+     * @param tagsProvider ITagProvider
+     */
+    public void unregister(ITagsProvider tagsProvider) {
+        if (providers.contains(tagsProvider)) {
+            providers.remove(tagsProvider);
+            createDefaults();
+        }
+    }
+
+    /**
+     * Processes all {@link #providers} on the start-up.
+     */
+    protected void createDefaults() {
+        // first create map of tags based on the providers priority
+        Map<String, String> all = new HashMap<>();
+        providers.stream()
+                .sorted(Comparator.comparingInt(ITagsProvider::getPriority).reversed())
+                .forEach(provider -> provider.getTags().forEach(all::putIfAbsent));
+
+        // then create key/value tags pairs for resolved map
+        commonTagKeys = new ArrayList<>();
+        TagContextBuilder tagContextBuilder = Tags.getTagger().emptyBuilder();
+        all.forEach((k, v) -> {
+            TagKey key = TagKey.create(k);
+            commonTagKeys.add(key);
+            tagContextBuilder.put(key, TagValue.create(v));
+        });
+        commonTagContext = tagContextBuilder.build();
+    }
+
+}

--- a/inspectit-oce-core/src/main/java/rocks/inspectit/oce/core/tags/CommonTagsManager.java
+++ b/inspectit-oce-core/src/main/java/rocks/inspectit/oce/core/tags/CommonTagsManager.java
@@ -52,11 +52,11 @@ public class CommonTagsManager {
     }
 
     /**
-     * Returns default tag context. For testing.
+     * Returns common tag context.
      *
-     * @return Returns default tag context.
+     * @return Returns common tag context.
      */
-    TagContext getCommonTagContext() {
+    public TagContext getCommonTagContext() {
         return commonTagContext;
     }
 
@@ -68,7 +68,7 @@ public class CommonTagsManager {
     public void register(ITagsProvider tagsProvider) {
         if (!providers.contains(tagsProvider)) {
             providers.add(tagsProvider);
-            createDefaults();
+            createCommonTagContext();
         }
     }
 
@@ -80,14 +80,14 @@ public class CommonTagsManager {
     public void unregister(ITagsProvider tagsProvider) {
         if (providers.contains(tagsProvider)) {
             providers.remove(tagsProvider);
-            createDefaults();
+            createCommonTagContext();
         }
     }
 
     /**
-     * Processes all {@link #providers} on the start-up.
+     * Processes all {@link #providers} and creates common context based on the providers priority.
      */
-    protected void createDefaults() {
+    private void createCommonTagContext() {
         // first create map of tags based on the providers priority
         Map<String, String> all = new HashMap<>();
         providers.stream()

--- a/inspectit-oce-core/src/main/java/rocks/inspectit/oce/core/tags/ITagsProvider.java
+++ b/inspectit-oce-core/src/main/java/rocks/inspectit/oce/core/tags/ITagsProvider.java
@@ -1,0 +1,44 @@
+package rocks.inspectit.oce.core.tags;
+
+import lombok.Getter;
+
+import java.util.Map;
+
+public interface ITagsProvider {
+
+    /**
+     * Returns priority of this tag providers, higher int values mean higher priority.
+     * <p>
+     * For convenience implementations can use {@link Priority#getValue()} to position them self in 3 main priorities (LOW, MEDIUM, HIGH), but are free to specify any int negative or positive value.
+     *
+     * @return Priority of this tag providers
+     */
+    int getPriority();
+
+    /**
+     * Get tags provided by this metrics providers.
+     *
+     * @return Get tags provided by this metrics providers.
+     */
+    Map<String, String> getTags();
+
+    /**
+     * Priority helper.
+     */
+    enum Priority {
+
+        LOW(-100),
+
+        MEDIUM(0),
+
+        HIGH(100);
+
+        @Getter
+        private final int value;
+
+        Priority(int value) {
+            this.value = value;
+        }
+    }
+
+}

--- a/inspectit-oce-core/src/main/java/rocks/inspectit/oce/core/tags/impl/EnvironmentTagsProvider.java
+++ b/inspectit-oce-core/src/main/java/rocks/inspectit/oce/core/tags/impl/EnvironmentTagsProvider.java
@@ -1,0 +1,83 @@
+package rocks.inspectit.oce.core.tags.impl;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import rocks.inspectit.oce.core.config.model.InspectitConfig;
+import rocks.inspectit.oce.core.tags.AbstractTagsProvider;
+import rocks.inspectit.oce.core.tags.ITagsProvider;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * {@link ITagsProvider} that provides the environment based tags like service name, host, etc.
+ */
+@Component
+@Slf4j
+public class EnvironmentTagsProvider extends AbstractTagsProvider {
+
+    /**
+     * Default constructor.
+     */
+    public EnvironmentTagsProvider() {
+        super("serviceName", "tags.providers.environment");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected boolean checkEnabledForConfig(InspectitConfig conf) {
+        return conf.getTags().getProviders().getEnvironment().isEnabled();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getPriority() {
+        return Priority.LOW.getValue();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected Map<String, String> resolveTagsInternal(InspectitConfig configuration) {
+        Map<String, String> envTags = new HashMap<>();
+        envTags.put("service-name", configuration.getServiceName());
+
+        if (configuration.getTags().getProviders().getEnvironment().isResolveHostName()) {
+            try {
+                envTags.put("host", resolveHostName());
+            } catch (UnknownHostException e) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Failed to resolve host name.", e);
+                }
+            }
+        }
+
+        if (configuration.getTags().getProviders().getEnvironment().isResolveHostAddress()) {
+            try {
+                envTags.put("host-address", resolveHostAddress());
+            } catch (UnknownHostException e) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Failed to resolve host address.", e);
+                }
+            }
+        }
+
+        return envTags;
+    }
+
+    private static String resolveHostName() throws UnknownHostException {
+        return InetAddress.getLocalHost().getHostName();
+    }
+
+    private static String resolveHostAddress() throws UnknownHostException {
+        return InetAddress.getLocalHost().getHostAddress();
+    }
+
+}

--- a/inspectit-oce-core/src/main/java/rocks/inspectit/oce/core/tags/impl/ExtrasTagsProvider.java
+++ b/inspectit-oce-core/src/main/java/rocks/inspectit/oce/core/tags/impl/ExtrasTagsProvider.java
@@ -1,0 +1,49 @@
+package rocks.inspectit.oce.core.tags.impl;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import rocks.inspectit.oce.core.config.model.InspectitConfig;
+import rocks.inspectit.oce.core.tags.AbstractTagsProvider;
+
+import java.util.Map;
+
+/**
+ * Tags providers for user defined extra tags.
+ */
+@Component
+@Slf4j
+public class ExtrasTagsProvider extends AbstractTagsProvider {
+
+    /**
+     * Default constructor.
+     */
+    public ExtrasTagsProvider() {
+        super("tags.extra");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected boolean checkEnabledForConfig(InspectitConfig conf) {
+        Map<String, String> extraMap = conf.getTags().getExtra();
+        return extraMap != null && extraMap.size() > 0;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getPriority() {
+        return Priority.HIGH.getValue();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected Map<String, String> resolveTagsInternal(InspectitConfig configuration) {
+        return configuration.getTags().getExtra();
+    }
+
+}

--- a/inspectit-oce-core/src/main/resources/config/default.yml
+++ b/inspectit-oce-core/src/main/resources/config/default.yml
@@ -3,6 +3,23 @@ inspectit:
   # the name of the service which is being instrumented
   service-name: "InspectIT Agent"
 
+  # defines common tags to be be set on the metrics
+  tags:
+    # different tag providers that can be configured
+    providers:
+      # environment provider adds 'service-name', 'host' and 'host-address' tags
+      environment:
+        # if environment provider is enabled
+        enabled: true
+        # should the host name be resolved using InetAddress.getLocalHost(), if false 'host' tag is not added by env provider
+        resolve-host-name: true
+        # should the host address be resolved using InetAddress.getLocalHost(), if false 'host-address' tag is not added by env provider
+        resolve-host-address: true
+
+    # specifies user defined tag keys and values as a map
+    # these tag values would overwrite any value added by the providers, thus you can easily overwrite tags values by your own
+    # extra:
+
   # all configurations sources
   config:
     # file based configuration - has the highest priority

--- a/inspectit-oce-core/src/main/resources/config/default.yml
+++ b/inspectit-oce-core/src/main/resources/config/default.yml
@@ -18,7 +18,7 @@ inspectit:
 
     # specifies user defined tag keys and values as a map
     # these tag values would overwrite any value added by the providers, thus you can easily overwrite tags values by your own
-    # extra:
+    extra: {}
 
   # all configurations sources
   config:

--- a/inspectit-oce-core/src/test/java/rocks/inspectit/oce/core/tags/CommonTagsManagerIntTest.java
+++ b/inspectit-oce-core/src/test/java/rocks/inspectit/oce/core/tags/CommonTagsManagerIntTest.java
@@ -1,0 +1,102 @@
+package rocks.inspectit.oce.core.tags;
+
+import io.opencensus.tags.InternalUtils;
+import io.opencensus.tags.TagContext;
+import io.opencensus.tags.TagKey;
+import io.opencensus.tags.TagValue;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
+import rocks.inspectit.oce.core.SpringTestBase;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CommonTagsManagerIntTest {
+
+    @Nested
+    @DirtiesContext
+    class Defaults extends SpringTestBase {
+
+        @Autowired
+        CommonTagsManager provider;
+
+        public void contextAvailable() {
+            TagContext commonTagContext = provider.getCommonTagContext();
+
+            assertThat(InternalUtils.getTags(commonTagContext)).isNotEmpty();
+        }
+
+        public void tagKeysCorrect() {
+            TagContext commonTagContext = provider.getCommonTagContext();
+            List<TagKey> commonTagKeys = provider.getCommonTagKeys();
+
+            assertThat(InternalUtils.getTags(commonTagContext))
+                    .allSatisfy(tag -> assertThat(commonTagKeys.contains(tag.getKey())).isTrue());
+        }
+
+        public void scopeAvailable() {
+            assertThat(provider.withCommonTagScope()).isNotNull();
+        }
+    }
+
+
+    @Nested
+    @DirtiesContext
+    @TestPropertySource(properties = {
+            "inspectit.tags.extra.service-name=my-service-name"
+    })
+    class PriorityRespected extends SpringTestBase {
+
+        @Autowired
+        CommonTagsManager provider;
+
+        @Test
+        public void extraOverwritesProviders() {
+            TagContext commonTagContext = provider.getCommonTagContext();
+
+            assertThat(InternalUtils.getTags(commonTagContext))
+                    .anySatisfy(tag -> {
+                        assertThat(tag.getKey()).isEqualTo(TagKey.create("service-name"));
+                        assertThat(tag.getValue()).isEqualTo(TagValue.create("my-service-name"));
+                    });
+        }
+    }
+
+    @Nested
+    @DirtiesContext
+    @TestPropertySource(properties = {
+            "inspectit.tags.extra.service-name=my-service-name"
+    })
+    class Updates extends SpringTestBase {
+
+        @Autowired
+        CommonTagsManager provider;
+
+        @Test
+        public void extraOverwritesProviders() {
+            updateProperties(
+                    properties -> properties
+                            .withProperty("inspectit.tags.providers.environment.resolve-host-address", Boolean.FALSE)
+                            .withProperty("inspectit.tags.providers.environment.resolve-host-name", Boolean.FALSE)
+                            .withProperty("inspectit.service-name", "some-service-name")
+                            .withProperty("inspectit.tags.extra.service-name", "my-service-name")
+            );
+
+            TagContext commonTagContext = provider.getCommonTagContext();
+
+            assertThat(InternalUtils.getTags(commonTagContext))
+                    .anySatisfy(tag -> {
+                        assertThat(tag.getKey()).isEqualTo(TagKey.create("service-name"));
+                        assertThat(tag.getValue()).isEqualTo(TagValue.create("my-service-name"));
+                    })
+                    .allSatisfy(tag -> {
+                        assertThat(tag.getKey()).isNotIn("host", "host-address");
+                    });
+        }
+    }
+
+}

--- a/inspectit-oce-core/src/test/java/rocks/inspectit/oce/core/tags/impl/EnvironmentTagsProviderIntTest.java
+++ b/inspectit-oce-core/src/test/java/rocks/inspectit/oce/core/tags/impl/EnvironmentTagsProviderIntTest.java
@@ -1,0 +1,119 @@
+package rocks.inspectit.oce.core.tags.impl;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
+import rocks.inspectit.oce.core.SpringTestBase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EnvironmentTagsProviderIntTest {
+
+    @Nested
+    @DirtiesContext
+    @TestPropertySource(properties = {
+            "inspectit.service-name=" + Defaults.SERVICE_NAME
+    })
+    class Defaults extends SpringTestBase {
+
+        static final String SERVICE_NAME = "SERVICE_NAME";
+
+        @Autowired
+        EnvironmentTagsProvider provider;
+
+        @Test
+        public void happyPath() {
+            assertThat(provider.isEnabled()).isTrue();
+            assertThat(provider.getTags())
+                    .hasSize(3)
+                    .containsEntry("service-name", SERVICE_NAME)
+                    .containsKey("host")
+                    .containsKey("host-address");
+        }
+
+    }
+
+    @Nested
+    @DirtiesContext
+    @TestPropertySource(properties = {
+            "inspectit.tags.providers.environment.resolve-host-name=false",
+            "inspectit.tags.providers.environment.resolve-host-address=false",
+    })
+    class Overwritten extends SpringTestBase {
+
+        @Autowired
+        EnvironmentTagsProvider provider;
+
+        @Test
+        public void happyPath() {
+            assertThat(provider.isEnabled()).isTrue();
+            assertThat(provider.getTags())
+                    .hasSize(1)
+                    .containsKeys("service-name");
+        }
+
+    }
+
+    @Nested
+    @DirtiesContext
+    @TestPropertySource(properties = {
+            "inspectit.tags.providers.environment.enabled=false"
+    })
+    class Disabled extends SpringTestBase {
+
+        @Autowired
+        EnvironmentTagsProvider provider;
+
+        @Test
+        public void happyPath() {
+            assertThat(provider.isEnabled()).isFalse();
+        }
+
+    }
+
+    @Nested
+    @DirtiesContext
+    @TestPropertySource(properties = {
+            "inspectit.tags.providers.environment.enabled=false"
+    })
+    class Update extends SpringTestBase {
+
+        @Autowired
+        EnvironmentTagsProvider provider;
+
+        @Test
+        public void enable() {
+            updateProperties(properties -> properties.withProperty("inspectit.tags.providers.environment.enabled", Boolean.TRUE));
+
+            assertThat(provider.isEnabled()).isTrue();
+            assertThat(provider.getTags()).hasSize(3);
+        }
+
+    }
+
+    @Nested
+    @DirtiesContext
+    class UpdateServiceName extends SpringTestBase {
+
+        @Autowired
+        EnvironmentTagsProvider provider;
+
+        @Test
+        public void happyPath() {
+            assertThat(provider.isEnabled()).isTrue();
+
+            updateProperties(
+                    properties -> properties
+                            .withProperty("inspectit.service-name", "updatedName")
+            );
+
+            assertThat(provider.isEnabled()).isTrue();
+            assertThat(provider.getTags()).hasSize(3)
+                    .containsEntry("service-name", "updatedName");
+        }
+
+    }
+
+}

--- a/inspectit-oce-core/src/test/java/rocks/inspectit/oce/core/tags/impl/ExtrasTagsProviderIntTest.java
+++ b/inspectit-oce-core/src/test/java/rocks/inspectit/oce/core/tags/impl/ExtrasTagsProviderIntTest.java
@@ -1,0 +1,73 @@
+package rocks.inspectit.oce.core.tags.impl;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
+import rocks.inspectit.oce.core.SpringTestBase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ExtrasTagsProviderIntTest {
+
+    @Nested
+    class Defaults extends SpringTestBase {
+
+        @Autowired
+        ExtrasTagsProvider provider;
+
+        @Test
+        public void happyPath() {
+            assertThat(provider.isEnabled()).isFalse();
+        }
+
+    }
+
+    @Nested
+    @DirtiesContext
+    @TestPropertySource(properties = {
+            "inspectit.tags.extra.key1=value1",
+            "inspectit.tags.extra[key2]=value2",
+    })
+    class Defined extends SpringTestBase {
+
+        @Autowired
+        ExtrasTagsProvider provider;
+
+        @Test
+        public void happyPath() {
+            assertThat(provider.isEnabled()).isTrue();
+            assertThat(provider.getTags())
+                    .hasSize(2)
+                    .containsEntry("key1", "value1")
+                    .containsEntry("key2", "value2");
+        }
+
+    }
+
+    @Nested
+    @DirtiesContext
+    @TestPropertySource(properties = {
+            "inspectit.tags.extra.key1=value1",
+            "inspectit.tags.extra[key2]=value2",
+    })
+    class Updated extends SpringTestBase {
+
+        @Autowired
+        ExtrasTagsProvider provider;
+
+        @Test
+        public void happyPath() {
+            updateProperties(properties -> properties.withProperty("inspectit.tags.extra.key1", "updatedValue"));
+
+            assertThat(provider.isEnabled()).isTrue();
+            assertThat(provider.getTags())
+                    .hasSize(2)
+                    .containsEntry("key1", "updatedValue")
+                    .containsEntry("key2", "value2");
+        }
+
+    }
+
+}

--- a/inspectit-oce-documentation/src/docs/asciidoc/_includes/monitoring-environment/common-tags.adoc
+++ b/inspectit-oce-documentation/src/docs/asciidoc/_includes/monitoring-environment/common-tags.adoc
@@ -1,0 +1,69 @@
+=== Common Tags
+
+inspectIT OCE provides a map of common tag keys and values that are used when recording all metrics.
+This features enables to "label" metrics collected with inspectIT OCE and share common information about a process or an environment where the process runs.
+The map can be <<User Defined Tags Provider,extended or overwritten by the user>> when this is required.
+
+Tags providers are responsible for extracting information from a specific source and provide a map of key value pairs that are then combined into the common tag context.
+Each provider specifies a priority and if same tag keys are provided by two providers, then the tag value from a provider with higher priority will be used.
+
+inspectIT OCE current supports the following tags providers:
+
+[cols="2,2,1,1,1",options="header"]
+|===
+|Provider |Tags provided |Supports run-time updates |Enabled by default |Priority
+|<<User Defined Tags>>
+|-
+|Yes
+|No
+|HIGH
+|<<Environment Tags>>
+|`service-name`, `host`, `host-address`
+|Yes
+|Yes
+|LOW
+|===
+
+WARNING: Run-time updates currently only support changing of a tag value, but not adding or removing tags.
+
+==== User Defined Tags
+
+User defined tags can be added to the common tag context by defining the `inspectit.tags.extra` property.
+
+.Setting the user defined tags using properties
+[source,properties]
+----
+inspectit.tags.extra.region=us-west-1
+inspectit.tags.extra.stage=preprod
+----
+
+.Setting the user defined tags using YAML file
+[source,YAML]
+----
+inspectit:
+  tags:
+    extra:
+      region: us-west-1
+      stage: preprod
+----
+
+==== Environment Tags
+The environment tags provider extends the common tag context by supplying information about the service name and a host.
+The service name is resolved from the `inspectit.service-name` property, while host information is extracted using `InetAddress.getLocalHost()`.
+
+NOTE: Note that on machines that have multiple network interfaces the `InetAddress.getLocalHost()` method might not provide desired values for host related tags.
+
+[cols="5,1,3",options="header"]
+.Properties related to the environment tags provider
+|===
+|Property |Default| Description
+|```inspectit.tags.providers.environment.enabled```
+|`true`
+|Enables or disables the provider.
+|```inspectit.tags.providers.environment.resolve-host-name```
+|`true`
+|If `false`, the tag `host` containing the resolved host name will not be provided.
+|```inspectit.tags.providers.environment.resolve-host-address```
+|`true`
+|If `false`, the tag `host-address` containing the resolved host IP address will not be provided.
+|===

--- a/inspectit-oce-documentation/src/docs/asciidoc/_includes/monitoring-environment/common-tags.adoc
+++ b/inspectit-oce-documentation/src/docs/asciidoc/_includes/monitoring-environment/common-tags.adoc
@@ -1,13 +1,13 @@
 === Common Tags
 
 inspectIT OCE provides a map of common tag keys and values that are used when recording all metrics.
-This features enables to "label" metrics collected with inspectIT OCE and share common information about a process or an environment where the process runs.
-The map can be <<User Defined Tags Provider,extended or overwritten by the user>> when this is required.
+This feature enables to "label" metrics collected with inspectIT OCE and to share common information about a process or an environment where the process runs.
+The map can be <<User Defined Tags,extended or overwritten by the user>> when this is required.
 
-Tags providers are responsible for extracting information from a specific source and provide a map of key value pairs that are then combined into the common tag context.
-Each provider specifies a priority and if same tag keys are provided by two providers, then the tag value from a provider with higher priority will be used.
+Tag provider is responsible for extracting information from a specific source and provides a map of key value pairs that are then combined into the common tag context.
+Each provider specifies a priority and if the same tag keys are supplied by two providers, then the tag value from the provider with higher priority will be used.
 
-inspectIT OCE current supports the following tags providers:
+inspectIT OCE current supports the following tag providers:
 
 [cols="2,2,1,1,1",options="header"]
 |===
@@ -48,10 +48,10 @@ inspectit:
 ----
 
 ==== Environment Tags
-The environment tags provider extends the common tag context by supplying information about the service name and a host.
-The service name is resolved from the `inspectit.service-name` property, while host information is extracted using `InetAddress.getLocalHost()`.
+The environment tag provider extends the common tag context by supplying information about the service name and the network host.
+The service name is resolved from the `inspectit.service-name` property, while the host information is extracted using `InetAddress.getLocalHost()`.
 
-NOTE: Note that on machines that have multiple network interfaces the `InetAddress.getLocalHost()` method might not provide desired values for host related tags.
+NOTE: On machines that have multiple network interfaces the `InetAddress.getLocalHost()` method might not provide desired values for host related tags.
 
 [cols="5,1,3",options="header"]
 .Properties related to the environment tags provider

--- a/inspectit-oce-documentation/src/docs/asciidoc/_includes/monitoring-environment/index.adoc
+++ b/inspectit-oce-documentation/src/docs/asciidoc/_includes/monitoring-environment/index.adoc
@@ -1,0 +1,3 @@
+== Monitoring Environment
+
+include::common-tags.adoc[]

--- a/inspectit-oce-documentation/src/docs/asciidoc/index.adoc
+++ b/inspectit-oce-documentation/src/docs/asciidoc/index.adoc
@@ -24,4 +24,6 @@ include::{include-dir}/configuration/index.adoc[]
 
 include::{include-dir}/metrics/index.adoc[]
 
+include::{include-dir}/monitoring-environment/index.adoc[]
+
 include::{include-dir}/appendix/index.adoc[]


### PR DESCRIPTION
Example usages:
* creating view
 ```
        View.create(View.Name.create("some/name"), "some desc", someMeasure, someAggregation, tagsProvider.getCommonTagKeys())
 ```
* recording metrics view
 ```
        try (Scope scope = tagsProvider.withCommonTagScope()) {
            Stats.getStatsRecorder().newMeasureMap().put(someMeasure, 1L).record();
        }
 ```

@JonasKunz let's disucss how should we document this

**Main challendge: How can common tags be included in metrics collected by the user using instrumentation lib?**
As OpenCensus does not provide any mechanism to set common tags, we would need to allow user to access them.. Maybe we can provide some bootstrap interface for this, that user could use to get it, but this way the bootstrap must be a compile depdency for  users as well. We would need to provide NoOp impl as well. I had idea to instrument all threads and add  `try (Scope scope = tagsProvider.withCommonTagScope())` as the first statemetnt on the `run()`, but this would work only for recording, not for view registration.