### PR TITLE
closes #18: Added handling of invalid startup configurations

### DIFF
--- a/inspectit-oce-core/src/main/java/rocks/inspectit/oce/core/AgentImpl.java
+++ b/inspectit-oce-core/src/main/java/rocks/inspectit/oce/core/AgentImpl.java
@@ -38,7 +38,6 @@ public class AgentImpl implements IAgent {
         ctx = new AnnotationConfigApplicationContext();
         ctx.setClassLoader(classloader);
         InspectitEnvironment environment = new InspectitEnvironment(ctx);
-        ctx.setEnvironment(environment);
 
         // once we have the environment, init the logging
         LogbackInitializer.initLogging(environment.getCurrentConfig());

--- a/inspectit-oce-core/src/main/java/rocks/inspectit/oce/core/config/InspectitEnvironment.java
+++ b/inspectit-oce-core/src/main/java/rocks/inspectit/oce/core/config/InspectitEnvironment.java
@@ -3,16 +3,18 @@ package rocks.inspectit.oce.core.config;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
+import org.springframework.beans.factory.config.BeanExpressionResolver;
 import org.springframework.boot.context.properties.bind.Binder;
 import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.core.env.MutablePropertySources;
-import org.springframework.core.env.PropertiesPropertySource;
-import org.springframework.core.env.PropertySources;
-import org.springframework.core.env.StandardEnvironment;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.expression.StandardBeanExpressionResolver;
+import org.springframework.core.env.*;
 import org.springframework.core.io.ClassPathResource;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
 import rocks.inspectit.oce.core.config.filebased.DirectoryPropertySource;
 import rocks.inspectit.oce.core.config.filebased.PropertyFileUtils;
 import rocks.inspectit.oce.core.config.model.InspectitConfig;
+import rocks.inspectit.oce.core.config.model.config.ConfigSettings;
 
 import javax.validation.ConstraintViolation;
 import javax.validation.Validation;
@@ -22,9 +24,11 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 /**
  * InspectIT Spring Environment.
@@ -35,8 +39,19 @@ import java.util.function.Consumer;
 @Slf4j
 public class InspectitEnvironment extends StandardEnvironment {
 
+    private static final String INSPECTIT_ROOT_PREFIX = "inspectit";
+    private static final String INSPECTIT_CONFIG_SETTINGS_PREFIX = "inspectit.config";
+
     private static final String DEFAULT_CONFIG_PATH = "/config/default.yml";
     private static final String DEFAULT_CONFIG_PROPERTYSOURCE_NAME = "inspectitDefaults";
+
+    private static final String FALLBACK_CONFIG_PATH = "/config/fallback.yml";
+    private static final String FALLBACK_CONFIG_PROPERTYSOURCE_NAME = "inspectitFallbackOverwrites";
+
+    /**
+     * The variable under which {@link #currentConfig)} is available in bean expressions, such as @Value annotations
+     */
+    private static final String INSPECTIT_CONFIG_BEAN_EXPRESSION_VARIABLE = "inspectit";
 
 
     /**
@@ -45,7 +60,7 @@ public class InspectitEnvironment extends StandardEnvironment {
      * This means that configurations loaded from items appearing earlier in the list overwrite configurations from items appearing later in the list.
      * In contrast items appearing first in the list can provide information for loading items appearing later in the list.
      */
-    private static final List<BiConsumer<MutablePropertySources, InspectitConfig>> CONFIGURATION_INIT_STEPS = Arrays.asList(
+    private static final List<BiConsumer<MutablePropertySources, ConfigSettings>> CONFIGURATION_INIT_STEPS = Arrays.asList(
             InspectitEnvironment::addFileBasedConfiguration
     );
 
@@ -65,8 +80,15 @@ public class InspectitEnvironment extends StandardEnvironment {
      */
     private Validator validator;
 
-    public InspectitEnvironment(ApplicationEventPublisher eventDrain) {
-        this.eventDrain = eventDrain;
+    /**
+     * Creates and applies an InspectitEnvironment onto the given context.
+     *
+     * @param ctx the context to apply this environemnt onto
+     */
+    public InspectitEnvironment(ConfigurableApplicationContext ctx) {
+        eventDrain = ctx;
+        ctx.setEnvironment(this);
+        ctx.addBeanFactoryPostProcessor(fac -> fac.setBeanExpressionResolver(getBeanExpressionResolver()));
     }
 
     /**
@@ -81,7 +103,9 @@ public class InspectitEnvironment extends StandardEnvironment {
     public synchronized void updatePropertySources(Consumer<MutablePropertySources> propertiesUpdater) {
         propertiesUpdater.accept(getPropertySources());
         InspectitConfig oldConfig = currentConfig;
-        reloadConfig();
+
+        Optional<InspectitConfig> newConfig = loadAndValidateFromProperties(INSPECTIT_ROOT_PREFIX, InspectitConfig.class);
+        newConfig.ifPresent(c -> currentConfig = c);
         if (!currentConfig.equals(oldConfig)) {
             val event = new InspectitConfigChangedEvent(this, oldConfig, currentConfig);
             eventDrain.publishEvent(event);
@@ -98,17 +122,71 @@ public class InspectitEnvironment extends StandardEnvironment {
         propertiesAccessor.accept(getPropertySources());
     }
 
-    private void reloadConfig() {
-        InspectitConfig newConfig = Binder.get(this).bind("inspectit", InspectitConfig.class).get();
+    /**
+     * Initialization of all configuration source
+     *
+     * @param propsList
+     */
+    @Override
+    protected void customizePropertySources(MutablePropertySources propsList) {
+        //include the standard sources (e.g. environment variables and properties)
+        super.customizePropertySources(propsList);
+
+        PropertySource defaultSettings = loadAgentResourceYaml(DEFAULT_CONFIG_PATH, DEFAULT_CONFIG_PROPERTYSOURCE_NAME);
+        propsList.addLast(defaultSettings);
+
+        Optional<ConfigSettings> appliedConfigSettings = initializeConfigurationSources(propsList);
+
+        log.info("Registered Configuration Sources:");
+        getPropertySources().stream().forEach(ps -> log.info("  {}", ps.getName()));
+
+        Optional<InspectitConfig> initialConfig = loadAndValidateFromProperties(INSPECTIT_ROOT_PREFIX, InspectitConfig.class);
+        if (initialConfig.isPresent()) {
+            currentConfig = initialConfig.get();
+        } else {
+            log.error("Startup configuration is not valid! Using fallback configuration but listening for configuration updates...");
+            PropertySource fallbackSettings = loadAgentResourceYaml(FALLBACK_CONFIG_PATH, FALLBACK_CONFIG_PROPERTYSOURCE_NAME);
+            val currentSources = propsList.stream().collect(Collectors.toList());
+            val fallbackSources = Arrays.<PropertySource<?>>asList(fallbackSettings, defaultSettings);
+
+            currentSources.forEach(ps -> propsList.remove(ps.getName()));
+            fallbackSources.forEach(ps -> propsList.addLast(ps));
+
+            currentConfig = loadAndValidateFromProperties(INSPECTIT_ROOT_PREFIX, InspectitConfig.class).get();
+
+            fallbackSources.forEach(ps -> propsList.remove(ps.getName()));
+            currentSources.forEach(ps -> propsList.addLast(ps));
+
+            appliedConfigSettings.ifPresent(currentConfig::setConfig);
+        }
+    }
+
+    /**
+     * Loads and validates a given bean from the environemnts proeprties.
+     *
+     * @param prefix      the prefix to use, e.g. "inspectit" for the root config object
+     * @param configClazz the class of the config to load
+     * @param <T>         the type of configClazz
+     * @return the loaded object in case of success or an empty optional otherwise
+     */
+    private <T> Optional<T> loadAndValidateFromProperties(String prefix, Class<T> configClazz) {
+        T newConfig;
+        try {
+            newConfig = Binder.get(this).bind(prefix, configClazz).get();
+        } catch (Exception e) {
+            log.error("Error loading the configuration '{}'.", prefix, e);
+            return Optional.empty();
+        }
         Validator validator = getValidator();
         val violations = validator.validate(newConfig);
         if (violations.isEmpty()) {
-            currentConfig = newConfig;
+            return Optional.of(newConfig);
         } else {
-            log.error("The given configuration is not valid! The currently active configuration will be kept.");
-            for (ConstraintViolation<InspectitConfig> vio : violations) {
+            log.error("Error loading the configuration '{}'.", prefix);
+            for (ConstraintViolation<T> vio : violations) {
                 log.error("{} (={}) => {}", CaseUtils.camelCaseToKebabCase(vio.getPropertyPath().toString()), vio.getInvalidValue(), vio.getMessage());
             }
+            return Optional.empty();
         }
     }
 
@@ -119,33 +197,45 @@ public class InspectitEnvironment extends StandardEnvironment {
         return validator;
     }
 
-    @Override
-    protected void customizePropertySources(MutablePropertySources propsList) {
-        //include the standard sources (e.g. environment variables and properties)
-        super.customizePropertySources(propsList);
-
-        addAgentDefaultYaml(propsList);
-
-        reloadConfig();
+    private Optional<ConfigSettings> initializeConfigurationSources(MutablePropertySources propsList) {
+        Optional<ConfigSettings> lastConfig = Optional.empty();
+        Optional<ConfigSettings> config = loadAndValidateFromProperties(INSPECTIT_CONFIG_SETTINGS_PREFIX, ConfigSettings.class);
         for (val initializer : CONFIGURATION_INIT_STEPS) {
-            initializer.accept(propsList, currentConfig);
-            reloadConfig();
+            if (!config.isPresent()) {
+                log.error("Error loading {}, aborting scanning for additional configuration sources!", INSPECTIT_CONFIG_SETTINGS_PREFIX);
+                break;
+            }
+            initializer.accept(propsList, config.get());
+            lastConfig = config;
+            config = loadAndValidateFromProperties(INSPECTIT_CONFIG_SETTINGS_PREFIX, ConfigSettings.class);
         }
-
-        log.info("Registered Configuration Sources:");
-        getPropertySources().stream().forEach(ps -> log.info("  {}", ps.getName()));
+        return config.isPresent() ? config : lastConfig;
     }
 
-    private static void addAgentDefaultYaml(MutablePropertySources propsList) {
-        ClassPathResource defaultYamlResource = new ClassPathResource(DEFAULT_CONFIG_PATH, InspectitEnvironment.class.getClassLoader());
+    private static PropertiesPropertySource loadAgentResourceYaml(String resourcePath, String propertySourceName) {
+        ClassPathResource defaultYamlResource = new ClassPathResource(resourcePath, InspectitEnvironment.class.getClassLoader());
         Properties defaultProps = PropertyFileUtils.readYamlFiles(defaultYamlResource);
-        propsList.addLast(new PropertiesPropertySource(DEFAULT_CONFIG_PROPERTYSOURCE_NAME, defaultProps));
+        return new PropertiesPropertySource(propertySourceName, defaultProps);
     }
 
-    private static void addFileBasedConfiguration(MutablePropertySources propsList, InspectitConfig currentConfig) {
-        String path = currentConfig.getConfig().getFileBased().getPath();
+    /**
+     * @return a bean expression resolver in which the #inspectit variable refers to the currently active configuration
+     */
+    private BeanExpressionResolver getBeanExpressionResolver() {
+        return new StandardBeanExpressionResolver() {
+            @Override
+            protected void customizeEvaluationContext(StandardEvaluationContext evalContext) {
+                super.customizeEvaluationContext(evalContext);
+                evalContext.setVariable(INSPECTIT_CONFIG_BEAN_EXPRESSION_VARIABLE, getCurrentConfig());
+            }
+        };
+    }
+
+
+    private static void addFileBasedConfiguration(MutablePropertySources propsList, ConfigSettings currentConfig) {
+        String path = currentConfig.getFileBased().getPath();
         Path dirPath = Paths.get(path);
-        boolean enabled = currentConfig.getConfig().getFileBased().isEnabled();
+        boolean enabled = currentConfig.getFileBased().isEnabled();
         boolean fileBasedConfigEnabled = enabled && path != null && !path.isEmpty();
         if (fileBasedConfigEnabled) {
             if (Files.exists(dirPath) && Files.isDirectory(dirPath)) {

--- a/inspectit-oce-core/src/main/java/rocks/inspectit/oce/core/config/SpringConfiguration.java
+++ b/inspectit-oce-core/src/main/java/rocks/inspectit/oce/core/config/SpringConfiguration.java
@@ -14,7 +14,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class SpringConfiguration {
 
     @Bean
-    public ScheduledExecutorService getScheduledExecutorService(@Value("${inspectit.thread-pool-size}") int poolSize) {
+    public ScheduledExecutorService getScheduledExecutorService(@Value("#{#inspectit.threadPoolSize}") int poolSize) {
         AtomicInteger threadCount = new AtomicInteger();
         return Executors.newScheduledThreadPool(poolSize, (runnable) -> {
             Thread t = Executors.defaultThreadFactory().newThread(runnable);

--- a/inspectit-oce-core/src/main/resources/config/fallback.yml
+++ b/inspectit-oce-core/src/main/resources/config/fallback.yml
@@ -1,0 +1,8 @@
+#------------------------
+# This file contains fallback configuration overwrites in case the agent is started with an invalid configuration
+# In this case, the agent tries to preserve the inspecit.config settings and to attach them to the fallback configuration
+# to make sure that runtime configuration updated are possible without a restart
+#------------------------
+inspectit:
+  metrics:
+    enabled: false

--- a/inspectit-oce-core/src/test/java/rocks/inspectit/oce/core/SpringTestBase.java
+++ b/inspectit-oce-core/src/test/java/rocks/inspectit/oce/core/SpringTestBase.java
@@ -92,8 +92,7 @@ public class SpringTestBase {
                     .filter(ps -> ps.getName() != StandardEnvironment.SYSTEM_PROPERTIES_PROPERTY_SOURCE_NAME)
                     .collect(Collectors.toList());
 
-            InspectitEnvironment env = new TestInspectitEnvironment(ctx);
-            ctx.setEnvironment(env);
+            new TestInspectitEnvironment(ctx);
         }
     }
 

--- a/inspectit-oce-core/src/test/java/rocks/inspectit/oce/core/config/FallbackConfigTest.java
+++ b/inspectit-oce-core/src/test/java/rocks/inspectit/oce/core/config/FallbackConfigTest.java
@@ -1,0 +1,23 @@
+package rocks.inspectit.oce.core.config;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+import rocks.inspectit.oce.core.SpringTestBase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestPropertySource(properties = {
+        "inspectit.thread-pool-size=iAmNotANumber"
+})
+public class FallbackConfigTest extends SpringTestBase {
+
+    @Autowired
+    InspectitEnvironment env;
+
+    @Test
+    public void testFallbackConfigurationActive() {
+        assertThat(env.getCurrentConfig().getThreadPoolSize()).isEqualTo(2);
+        assertThat(env.getCurrentConfig().getMetrics().isEnabled()).isFalse();
+    }
+}

--- a/inspectit-oce-core/src/test/java/rocks/inspectit/oce/core/config/InvalidConfigurationUpdateTest.java
+++ b/inspectit-oce-core/src/test/java/rocks/inspectit/oce/core/config/InvalidConfigurationUpdateTest.java
@@ -1,0 +1,39 @@
+package rocks.inspectit.oce.core.config;
+
+import ch.qos.logback.classic.Level;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
+import rocks.inspectit.oce.core.SpringTestBase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class InvalidConfigurationUpdateTest extends SpringTestBase {
+
+    @Autowired
+    InspectitEnvironment env;
+
+    @Test
+    @DirtiesContext
+    public void testPreviousConfigMaintainedOnInvalidUpdate() {
+        updateProperties(mp -> {
+            mp.setProperty("inspectit.service-name", "ConfA");
+        });
+        assertThat(env.getCurrentConfig().getServiceName()).isEqualTo("ConfA");
+        assertNoLogsOfLevelOrGreater(Level.WARN);
+        updateProperties(mp -> {
+            mp.setProperty("inspectit.service-name", "ConfB");
+            mp.setProperty("inspectit.thread-pool-size", "-1");
+        });
+        assertLogsOfLevelOrGreater(Level.ERROR);
+        assertThat(env.getCurrentConfig().getServiceName()).isEqualTo("ConfA");
+
+        //Ensure that fixing the config is possible
+        updateProperties(mp -> {
+            mp.setProperty("inspectit.service-name", "ConfC");
+            mp.setProperty("inspectit.thread-pool-size", "2");
+        });
+        assertThat(env.getCurrentConfig().getServiceName()).isEqualTo("ConfC");
+        assertThat(env.getCurrentConfig().getThreadPoolSize()).isEqualTo(2);
+    }
+}

--- a/inspectit-oce-documentation/src/docs/asciidoc/_includes/configuration/configuration-basics.adoc
+++ b/inspectit-oce-documentation/src/docs/asciidoc/_includes/configuration/configuration-basics.adoc
@@ -10,6 +10,11 @@ Configuration properties are considered in inspectIT OCE in the following order:
 .. <<File-based Configuration,File-based configuration>>
 . <<All Configuration Options,inspectIT OCE defaults>>
 
+When an invalid configuration is given to inspectIT on startup, the agent will use a fallback configuration.
+In this fallback configuration, the agent is inactive with the exception of listening for configuration updates.
+
+When giving an invalid configuration through a runtime update to the agent, the agent will simply retain the previous configuration.
+
 The overview of all available inspectIT OCE configuration properties is given in the <<All Configuration Options>> section.
 
 ==== Java System Properties


### PR DESCRIPTION
The configuration loading process has been altered as follows.
Intially, the agent only loads the "inspectit.config" part from the configuration for parsing all configuration sources.
Afterwards, it tries to load the entrie configuration. If this fails, it will use a fallback configuration where everything is disabled. This fallback configuration however will retain the previously loaded "inspectit.config" part, which means that config updates can be passed to the agent.