### PR TITLE
Added note to docu to ensure that docker has enough main memory

### DIFF
--- a/inspectit-oce-documentation/src/docs/asciidoc/_includes/getting-started/docker-compose-example.adoc
+++ b/inspectit-oce-documentation/src/docs/asciidoc/_includes/getting-started/docker-compose-example.adoc
@@ -29,6 +29,7 @@ All of the demo scenarios are fully configured with predefined dashboards, *so y
 ==== Launching the Demo
 
 *Pre-requisites:* To launch the demo, https://www.docker.com/[Docker] needs to be installed on your system.
+If you use Docker-for-Windows or run Docker in a virtual machine, ensure that Docker has at least 4gb main memory assigned.
 
 
 Either https://github.com/inspectIT/inspectit-oce/archive/master.zip[download] or https://github.com/inspectIT/inspectit-oce[clone the inspectit-oce GitHub repository].


### PR DESCRIPTION
When starting the Demo on Docker-for-Windows with default settings it fails to start because of too low (2gb) default memory settings. The disk usage goes to > 100mb/s because the system is permanently swapping memory. I added a note to the documentation to prevent this.